### PR TITLE
Update mixer as default page and adjust pricing

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -23,7 +23,7 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Navigate to="/fragrances" replace />} />
+          <Route path="/" element={<PerfumeMixer />} />
           <Route path="/fragrances" element={<Index />} />
           <Route path="/compare-intro" element={<CompareIntro />} />
           <Route path="/compare" element={<Compare />} />

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -43,7 +43,10 @@ export function Header() {
               const isActive = item.href === location.pathname;
 
               const base = "flex items-center gap-2 px-3 py-2 rounded-lg font-semibold transition-all duration-200";
-              const classes = isActive
+              const isMixer = item.name === "Mixer";
+              const classes = isMixer
+                ? `${base} bg-gold-500 text-black-950 shadow-md`
+                : isActive
                 ? `${base} bg-gold-500 text-black-950 shadow-md`
                 : `${base} text-gold-300 hover:bg-gold-600 hover:text-black-950`;
 
@@ -80,13 +83,14 @@ export function Header() {
               {navigation.map((item) => {
                 const Icon = item.icon;
                 const isActive = item.href === location.pathname;
+                const isMixer = item.name === "Mixer";
                 return (
                   <Link
                     key={item.name}
                     to={item.href}
                     onClick={() => setIsMobileMenuOpen(false)}
                     className={`flex items-center gap-3 px-3 py-2 rounded-lg font-semibold transition-colors ${
-                      isActive
+                      isMixer || isActive
                         ? "bg-gold-500 text-black-950"
                         : "text-gold-300 hover:bg-gold-600 hover:text-black-950"
                     }`}

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -43,10 +43,7 @@ export function Header() {
               const isActive = item.href === location.pathname;
 
               const base = "flex items-center gap-2 px-3 py-2 rounded-lg font-semibold transition-all duration-200";
-              const emphasized = item.name === "Quiz";
-              const classes = emphasized
-                ? `${base} bg-gold-500 text-black-950 shadow-md`
-                : isActive
+              const classes = isActive
                 ? `${base} bg-gold-500 text-black-950 shadow-md`
                 : `${base} text-gold-300 hover:bg-gold-600 hover:text-black-950`;
 
@@ -54,7 +51,7 @@ export function Header() {
                 <Link key={item.name} to={item.href} className={classes}>
                   <Icon className="w-6 h-6" />
                   {item.name}
-                                  </Link>
+                </Link>
               );
             })}
           </nav>
@@ -83,24 +80,20 @@ export function Header() {
               {navigation.map((item) => {
                 const Icon = item.icon;
                 const isActive = item.href === location.pathname;
-                const emphasized = item.name === "Quiz";
-
                 return (
                   <Link
                     key={item.name}
                     to={item.href}
                     onClick={() => setIsMobileMenuOpen(false)}
                     className={`flex items-center gap-3 px-3 py-2 rounded-lg font-semibold transition-colors ${
-                      emphasized
-                        ? "bg-gold-500 text-black-950"
-                        : isActive
+                      isActive
                         ? "bg-gold-500 text-black-950"
                         : "text-gold-300 hover:bg-gold-600 hover:text-black-950"
                     }`}
                   >
                     <Icon className="w-6 h-6" />
                     {item.name}
-                                      </Link>
+                  </Link>
                 );
               })}
             </div>

--- a/client/components/PricingBanner.tsx
+++ b/client/components/PricingBanner.tsx
@@ -21,7 +21,7 @@ export function PricingBanner() {
                 30ml:
               </span>
               <Badge className="bg-gold-600 text-black-950 font-bold text-xs">
-                $29.99
+                $34.99
               </Badge>
             </div>
             <div className="flex items-center gap-1">
@@ -37,7 +37,7 @@ export function PricingBanner() {
                 100ml:
               </span>
               <Badge className="bg-gold-600 text-black-950 font-bold text-xs">
-                $74.99
+                $69.99
               </Badge>
             </div>
           </div>

--- a/client/components/StatsSection.tsx
+++ b/client/components/StatsSection.tsx
@@ -19,7 +19,7 @@ export function StatsSection() {
     {
       icon: Heart,
       label: "Starting From",
-      value: "$29.99",
+      value: "$34.99",
       description: "Unbeatable prices",
     },
     {

--- a/client/data/perfumes.ts
+++ b/client/data/perfumes.ts
@@ -25,7 +25,7 @@ export interface Perfume {
 
 // Standard Golden Aroma pricing
 export const standardSizes: PerfumeSize[] = [
-  { size: "30ml", price: 29.99 },
+  { size: "30ml", price: 34.99 },
   { size: "50ml", price: 44.99 },
   { size: "100ml", price: 69.99 },
 ];
@@ -57,7 +57,7 @@ export const perfumes: Perfume[] = [
     description:
       "A luminous and sophisticated fragrance inspired by the iconic Baccarat Rouge 540.",
     sizes: [
-      { size: "30ml", price: 29.99, originalPrice: 200 },
+      { size: "30ml", price: 34.99, originalPrice: 200 },
       { size: "50ml", price: 44.99, originalPrice: 295 },
       { size: "100ml", price: 69.99, originalPrice: 425 },
     ],

--- a/client/pages/PerfumeMixer.tsx
+++ b/client/pages/PerfumeMixer.tsx
@@ -924,7 +924,7 @@ export default function PerfumeMixer() {
 
                             setIngredients(balancedIngredients);
                           }}
-                          showCompareButton={false}
+                          
                         />
                       </div>
                     ))}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build",
     "build:server": "vite build --config vite.config.server.ts",
-    "start": "node dist/server/node-build.mjs",
+    "start": "node dist/server/production.mjs",
     "test": "vitest --run",
     "format.fix": "prettier --write .",
     "typecheck": "tsc"

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -1,0 +1,3 @@
+export interface DemoResponse {
+  message: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(({ mode }) => ({
   build: {
     outDir: "dist/spa",
   },
-  plugins: [react({ fastRefresh: false }), expressPlugin()],
+  plugins: [react(), expressPlugin()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./client"),


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements three key changes:
1. Make the mixer the first/default page when users visit the site
2. Update pricing structure with 30ml at $34.99 and 100ml at $69.99
3. Ensure the mixer navigation item is always highlighted while removing permanent highlighting from the quiz selection

## Code changes

- **Routing**: Changed default route from `/fragrances` redirect to direct `PerfumeMixer` component
- **Navigation**: Updated header logic to highlight "Mixer" instead of "Quiz" in both desktop and mobile views
- **Pricing**: Updated pricing across multiple components:
  - 30ml price changed from $29.99 to $34.99
  - 100ml price changed from $74.99 to $69.99
  - Updated pricing in PricingBanner, StatsSection, and perfumes data
- **Build config**: Minor updates to build script and vite configuration
- **API**: Added shared API interface fileTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/834eac77c2564a95a86acd7670700805/zen-lab)

👀 [Preview Link](https://834eac77c2564a95a86acd7670700805-zen-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>834eac77c2564a95a86acd7670700805</projectId>-->
<!--<branchName>zen-lab</branchName>-->