### PR TITLE
Fix CardHeader size by adding flex-none class

### DIFF
--- a/client/components/ui/card.tsx
+++ b/client/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-6 flex-none", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Purpose
The user identified that the CardHeader component area should never change size and was experiencing unwanted flexibility. This change ensures the header maintains a fixed size regardless of its container's flex behavior.

## Code changes
- Added `flex-none` class to the CardHeader component's className in `/client/components/ui/card.tsx`
- This prevents the header from growing or shrinking when used within flex containers
- The change maintains all existing styling while fixing the size stability issueTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/07196de760544fd98b3130f77699ff86/aura-studio)

👀 [Preview Link](https://07196de760544fd98b3130f77699ff86-aura-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>07196de760544fd98b3130f77699ff86</projectId>-->
<!--<branchName>aura-studio</branchName>-->