### PR TITLE
Remove internal scrollbars and enable unlimited height

### DIFF
--- a/client/global.css
+++ b/client/global.css
@@ -104,9 +104,9 @@
     height: -webkit-fill-available;
   }
   html, body {
-    height: auto;
+    height: 100%;
     min-height: 100%;
-    overflow-y: auto;
+    overflow: hidden;
   }
   #root {
     min-height: 100svh;

--- a/client/global.css
+++ b/client/global.css
@@ -137,3 +137,36 @@
     .min-h-screen { min-height: 100svh !important; }
   }
 }
+
+/* Make inner containers expand and remove internal scrollbars */
+/* Targets common Tailwind utility classes generated in this project */
+[class*="overflow-y-auto"],
+[class*="overflow-auto"],
+[class*="overflow-y-scroll"],
+[class*="overflow-scroll"],
+[class*="overflow-x-auto"],
+[class*="overflow-x-scroll"] {
+  overflow: visible !important;
+}
+
+/* Remove max-height constraints applied by Tailwind utilities like max-h-[600px], max-h-screen */
+[class*="max-h-"] {
+  max-height: none !important;
+  height: auto !important;
+}
+
+/* Ensure scroll-area component doesn't force inner scrolling */
+.scroll-area, .scroll-area * {
+  overflow: visible !important;
+}
+
+/* For elements using inline style of max-height via style attribute, prefer visible as well */
+[style*="max-height"] {
+  max-height: none !important;
+  height: auto !important;
+}
+
+/* Keep body scrolling enabled */
+html, body {
+  overflow-y: auto !important;
+}

--- a/client/global.css
+++ b/client/global.css
@@ -104,9 +104,9 @@
     height: -webkit-fill-available;
   }
   html, body {
-    height: 100%;
+    height: auto;
     min-height: 100%;
-    overflow: hidden;
+    overflow-y: auto;
   }
   #root {
     min-height: 100svh;


### PR DESCRIPTION
## Purpose

Based on user feedback, the goal is to eliminate internal scrolling within the application and allow unlimited height expansion. Users want the app to have unlimited length without any internal scroll containers, while maintaining the main body scroll functionality.

## Code changes

Added comprehensive CSS overrides in `global.css` to:
- Force `overflow: visible` on all Tailwind overflow utility classes (`overflow-y-auto`, `overflow-auto`, etc.)
- Remove max-height constraints from Tailwind `max-h-*` utilities 
- Override scroll-area component styling to prevent internal scrolling
- Remove inline max-height styles via attribute selectors
- Preserve body-level scrolling with `overflow-y: auto` on html/body elements

These changes ensure all content expands naturally without internal scroll containers while keeping the main page scrollable.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/07196de760544fd98b3130f77699ff86/cosmos-studio)

👀 [Preview Link](https://07196de760544fd98b3130f77699ff86-cosmos-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>07196de760544fd98b3130f77699ff86</projectId>-->
<!--<branchName>cosmos-studio</branchName>-->